### PR TITLE
Pinning DeepDiff to 6.2.2 as 6.2.3 needs a rust compiler.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
-deepdiff
+deepdiff == 6.2.2  # 6.2.3 needs a rust compiler
 lightkube
 lightkube-models
 parse


### PR DESCRIPTION


## Issue
<!-- What issue is this PR trying to solve? -->

`DeepDiff 6.2.3` started depending on a new library, `orjson`, that needs a rust compiler. This breaks current charm packing as we're not installing a rust compiler.

## Solution
<!-- A summary of the solution addressing the above issue -->

Pinning the dependency to the exact previous lib version.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Deferring any further action here to see what direction takes the team. We may simplify the code around DeepDiff and not use it, install a rust compiler, etc..

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Pack the charm and be happy.