### PR TITLE
Integrate prometheus

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2022-2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: pushgateway-k8s
@@ -35,3 +35,5 @@ resources:
 provides:
   metrics-endpoint:
     interface: prometheus_scrape
+  push-endpoint:
+    interface: pushgateway

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: prometheus-pushgateway-k8s
+name: pushgateway-k8s
 assumes:
   - k8s-api
 
@@ -15,9 +15,9 @@ description: |
 
 containers:
   pushgateway:
-    resource: prometheus-pushgateway-image
+    resource: pushgateway-image
     mounts:
-      - storage: prometheus-pushgateway-store
+      - storage: pushgateway-store
         location: /data
 
 storage:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.5.0
-deepdiff
+deepdiff == 6.2.2  # 6.2.3 needs a rust compiler
 lightkube
 lightkube-models
 parse

--- a/tests/integration/test_prometheus_integration.py
+++ b/tests/integration/test_prometheus_integration.py
@@ -1,0 +1,119 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import List
+
+import aiohttp
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+class Prometheus:
+    """Utility to get information from a Prometheus service."""
+
+    def __init__(self, host: str):
+        self.base_url = f"http://{host}:9090"
+
+    async def is_ready(self) -> bool:
+        """Send a GET request to check readiness."""
+        url = f"{self.base_url}/-/ready"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                return response.status == 200
+
+    async def labels(self) -> List[str]:
+        """Send a GET request to get labels."""
+        url = f"{self.base_url}/api/v1/label/__name__/values"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                result = await response.json()
+        return result["data"] if result["status"] == "success" else []
+
+
+@pytest.mark.abort_on_fail
+async def test_prometheus_integration(ops_test: OpsTest):
+    """Validate the integration between the Pushgateway and Prometheous."""
+    prometheus_app_name = "prometheus"
+    tester_name = "testingcharm"
+    apps = [APP_NAME, prometheus_app_name, tester_name]
+    pushgateway_charm = await ops_test.build_charm(".")
+    tester_charm = await ops_test.build_charm("tests/testingcharm")
+
+    image = METADATA["resources"]["pushgateway-image"]["upstream-source"]
+    resources = {"pushgateway-image": image}
+
+    await asyncio.gather(
+        ops_test.model.deploy(
+            pushgateway_charm,
+            resources=resources,
+            application_name=APP_NAME,
+        ),
+        ops_test.model.deploy(
+            "prometheus-k8s",
+            application_name=prometheus_app_name,
+            channel="stable",
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            tester_charm,
+            application_name=tester_name,
+        ),
+    )
+    logger.info("All services deployed")
+
+    # do not wait for the testing charm here, as it will be blocked until is
+    # related to the pushgateway charm
+    main_apps = [APP_NAME, prometheus_app_name]
+    await ops_test.model.wait_for_idle(
+        apps=main_apps, status="active", wait_for_units=1, idle_period=90)
+    await ops_test.model.wait_for_idle(apps=[tester_name], status="blocked", wait_for_units=1)
+    logger.info("Pushgateway and Prometheus active, testing charm waiting for the relation")
+
+    # prepare the Prometheus helper and check it's ready
+    status = await ops_test.model.get_status()
+    app = status["applications"][prometheus_app_name]
+    host = app["units"][f"{prometheus_app_name}/0"]["address"]
+    prometheus = Prometheus(host)
+    assert await prometheus.is_ready()
+    logger.info("Prometheus ready")
+
+    await asyncio.gather(
+        ops_test.model.add_relation(
+            f"{APP_NAME}:metrics-endpoint", f"{prometheus_app_name}:metrics-endpoint"
+        ),
+        ops_test.model.add_relation(
+            f"{tester_name}:pushgateway", f"{APP_NAME}:push-endpoint"
+        ),
+    )
+    logger.info("Relations issued")
+
+    # A considerable idle_period is needed to guarantee metrics show up in prometheus
+    # (60 sec was not enough).
+    await ops_test.model.wait_for_idle(apps=apps, status="active", idle_period=90)
+    logger.info("All services ready")
+
+    # run the action to push a metric
+    tester_unit = ops_test.model.applications[tester_name].units[0]
+    test_metric = "some_testing_metric"
+    action = await tester_unit.run_action("send-metric", name=test_metric, value="3.14")
+    result = (await action.wait()).results
+    assert result["status-code"] == "200"
+    logger.info("Metric sent to the Pushgateway")
+
+    for i in range(20):
+        labels = await prometheus.labels()
+        if test_metric in labels:
+            logger.info("Metric shown in Prometheus")
+            break
+        await asyncio.sleep(5)
+    else:
+        pytest.fail("Metric didn't get to Prometheus")

--- a/tests/testingcharm/.gitignore
+++ b/tests/testingcharm/.gitignore
@@ -1,0 +1,9 @@
+venv/
+build/
+*.charm
+.tox/
+.coverage
+__pycache__/
+*.py[cod]
+.idea
+.vscode/

--- a/tests/testingcharm/README.md
+++ b/tests/testingcharm/README.md
@@ -1,0 +1,29 @@
+# testingcharm
+
+Charm to support the testing of the Prometheus Pushgateway charm and its library.
+
+
+## How to use it
+
+Pack and deploy it:
+
+```
+charmcraft pack
+juju deploy ./testingcharm_ubuntu-22.04-amd64.charm
+```
+
+It should be left in "blocked" state, waiting for the proper relation.
+
+Relate it with the Pushgateway:
+
+```
+juju relate pushgateway-k8s testingcharm
+```
+
+Now it should be "active".
+
+Use its action to send a metric to the Pushgateway:
+
+```
+juju run testingcharm/0 send-metric name=some_metric value="'3.42'"
+```

--- a/tests/testingcharm/actions.yaml
+++ b/tests/testingcharm/actions.yaml
@@ -1,0 +1,10 @@
+send-metric:
+  description: Send a metric to the Prometheus Pushgateway
+  params:
+    name:
+      type: string
+      description: The metric name
+    value:
+      type: string
+      description: The metric value (float)
+  required: [name, value]

--- a/tests/testingcharm/charmcraft.yaml
+++ b/tests/testingcharm/charmcraft.yaml
@@ -1,0 +1,11 @@
+# This file configures Charmcraft.
+# See https://juju.is/docs/sdk/charmcraft-config for guidance.
+
+type: charm
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"

--- a/tests/testingcharm/metadata.yaml
+++ b/tests/testingcharm/metadata.yaml
@@ -1,0 +1,11 @@
+name: testingcharm
+display-name: Pushgateway Integration Test Charm
+summary: A charm to test integration with the Prometheus Pushgateway charm
+
+description: |
+  Charm that just integrates with the Prometheus Pushgateway charm and provides an
+  action to send metrics.
+
+requires:
+  pushgateway:
+    interface: pushgateway

--- a/tests/testingcharm/requirements.txt
+++ b/tests/testingcharm/requirements.txt
@@ -1,0 +1,2 @@
+ops >= 1.5.0
+requests

--- a/tests/testingcharm/src/charm.py
+++ b/tests/testingcharm/src/charm.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2023 Facundo Batista
+# See LICENSE file for licensing details.
+#
+# Learn more at: https://juju.is/docs/sdk
+
+"""Pushgateway Integration Test Charm.
+
+A charm to test integration with the Prometheus Pushgateway charm. It just integrates
+with the Prometheus Pushgateway charm and provides an action to send metrics there.
+"""
+
+import json
+import logging
+
+import requests
+
+from ops.charm import CharmBase, ActionEvent, HookEvent
+from ops.framework import StoredState
+from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus
+
+# Log messages can be retrieved using juju debug-log
+logger = logging.getLogger(__name__)
+
+
+class TestingcharmCharm(CharmBase):
+    """Charm the service."""
+
+    _stored = StoredState()
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._stored.set_default(pushgateway_url=None)
+
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.pushgateway_relation_created, self._on_push_relation)
+        self.framework.observe(self.on.pushgateway_relation_changed, self._on_push_relation)
+        self.framework.observe(self.on.send_metric_action, self._on_send_metric)
+
+    def _on_install(self, _) -> None:
+        """Installed, needs the relation."""
+        self.unit.status = BlockedStatus("needs the relation with the pushgateway")
+
+    def _on_push_relation(self, event: HookEvent) -> None:
+        """Receive the push endpoint information."""
+        raw = event.relation.data[event.app].get("push-endpoint")
+        if raw is not None:
+            logger.info("Received push endpoint information: %r", raw)
+            info = json.loads(raw)
+            self._stored.pushgateway_url = "http://{hostname}:{port}/".format_map(info)
+            self.unit.status = ActiveStatus()
+
+    def _on_send_metric(self, event: ActionEvent) -> None:
+        if self._stored.pushgateway_url is None:
+            event.fail("Testing charm not properly related to the Prometheus Pushgateway.")
+            return
+
+        name = event.params["name"].strip()
+        if " " in name:
+            event.fail("The metric name cannot contain spaces.")
+            return
+        try:
+            value = float(event.params["value"])
+        except ValueError:
+            event.fail("The metric value must be a float.")
+            return
+
+        payload = f"{name} {value}\n"
+        try:
+            payload_bytes = payload.encode("ascii")
+        except UnicodeEncodeError:
+            event.fail("The metric name must be ASCII.")
+            return
+
+        post_url = self._stored.pushgateway_url + "metrics/job/testjob"
+        resp = requests.post(post_url, data=payload_bytes)
+        event.set_results({"status-code": str(resp.status_code), "content": resp.text})
+
+
+if __name__ == "__main__":  # pragma: nocover
+    main(TestingcharmCharm)

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,7 @@ deps =
     pytest
     juju
     pytest-operator
+    aiohttp
     -r{toxinidir}/requirements.txt
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
## Issue

Part of this was already done, but now everything is complete and with an integration test.

Also included in `tests/testingcharm` a charm that can be deployed together with the Pushgateway that provides an action to send metrics to it (see its README for more details).

## Testing Instructions

Inject metrics with the testing charm's action (see its README for detailed instructions), then point the browser to the Prometheu's IP (port 9090), and voilá.