### PR TITLE
feat: add charm tracing

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -83,6 +83,18 @@ requires:
     limit: 1
     description: |
       Receives Loki's push api endpoint address to push logs to, and forwards charm's built-in alert rules to Loki.
+  charm-tracing:
+    interface: tracing
+    optional: true
+    limit: 1
+    description: |
+      Enables sending charm hook traces to a distributed tracing backend such as Tempo.
+  receive-ca-cert:
+    interface: certificate_transfer
+    optional: true
+    limit: 1
+    description: |
+      Receives a CA certificate used to validate TLS connections to the charm tracing backend.
 
 peers:
   pushgateway-peers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.0"
 requires-python = "~=3.8"
 
 dependencies = [
-  "ops>=2.2",
+  "ops[tracing]>=2.2",
   "parse",
   "cosl",
   "jsonschema",
@@ -25,11 +25,16 @@ dev = [
   "pytest",
   "coverage[toml]",
   "ops[testing]",
-  # Integration
+  # Integration (pytest-operator suite)
   "juju>=3.5",
   "pytest-operator>=0.39",
   "aiohttp",
   "sh",
+  # Integration (jubilant suite — charm tracing)
+  "jubilant",
+  "pytest-jubilant",
+  "requests",
+  "tenacity",
 ]
 
 # Testing tools configuration

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ import socket
 import typing
 from typing import Any, Dict, List, Optional
 
+import ops_tracing
 import yaml
 from charms.catalogue_k8s.v0.catalogue import CatalogueConsumer, CatalogueItem
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
@@ -98,6 +99,13 @@ class PrometheusPushgatewayK8SOperatorCharm(CharmBase):
         # Enable log forwarding for Loki and other charms that implement loki_push_api
         self._logging = LogProxyConsumer(
             self, relation_name="log-proxy", log_files=[PUSHGATEWAY_LOG]
+        )
+
+        # Emit charm hook traces to a tracing backend (e.g. Tempo); both relations are optional.
+        self.charm_tracing = ops_tracing.Tracing(
+            self,
+            tracing_relation_name="charm-tracing",
+            ca_relation_name="receive-ca-cert",
         )
 
         self.framework.observe(self._cert_handler.on.cert_changed, self._on_server_cert_changed)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,12 +39,24 @@ def timed_memoizer(func):
 @pytest.fixture(scope="module")
 @timed_memoizer
 async def pushgateway_charm(ops_test: OpsTest) -> Path:
-    """Prometheus Pushgateway charm used for integration testing."""
+    """Prometheus Pushgateway charm used for the pytest-operator (OpsTest) integration tests."""
     if charm_file := os.environ.get("CHARM_PATH"):
         return Path(charm_file)
 
     charm = await ops_test.build_charm(".")
     return charm
+
+
+@pytest.fixture(scope="session")
+def charm() -> Path:
+    """Packed charm for the jubilant tests: ``CHARM_PATH``, else a local ``*.charm``."""
+    if charm_file := os.environ.get("CHARM_PATH"):
+        return Path(charm_file).resolve()
+
+    charms = list(Path(".").glob("*.charm"))
+    assert charms, "No *.charm found; run `charmcraft pack` or set CHARM_PATH"
+    assert len(charms) == 1, f"Found more than one charm, cannot pick: {charms}"
+    return charms[0].resolve()
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/tempo_helpers.py
+++ b/tests/integration/tempo_helpers.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helpers to deploy a monolithic Tempo stack and query ingested traces.
+
+jubilant/sync; kept separate from the OpsTest/async ``helpers.py``.
+"""
+
+from typing import List, Set, cast
+
+import jubilant
+import requests
+from jubilant import Juju
+
+TEMPO = "tempo"
+TEMPO_WORKER = "tempo-worker"
+# An app named "s3" collides with Kubernetes' S3_PORT env var, which seaweedfs's `weed`
+# binary tries to parse as a flag and crashes on. Use any other name.
+S3_APP = "s3-app"
+# Tempo's current builds are on the `dev` track.
+TEMPO_CHANNEL = "dev/edge"
+
+
+def deploy_monolithic_tempo_cluster(juju: Juju) -> None:
+    """Deploy a monolithic Tempo cluster: coordinator + worker + a seaweedfs S3 backend."""
+    juju.deploy("tempo-coordinator-k8s", app=TEMPO, channel=TEMPO_CHANNEL, trust=True)
+    juju.deploy("tempo-worker-k8s", app=TEMPO_WORKER, channel=TEMPO_CHANNEL, trust=True)
+    juju.deploy("seaweedfs-k8s", app=S3_APP, channel="latest/edge")
+
+    juju.integrate(TEMPO, TEMPO_WORKER)
+    juju.integrate(f"{TEMPO}:s3", S3_APP)
+
+    juju.wait(
+        lambda status: jubilant.all_active(status, TEMPO, TEMPO_WORKER, S3_APP),
+        error=jubilant.any_error,
+        timeout=1000,
+    )
+
+
+def get_app_ip_address(juju: Juju, app_name: str) -> str:
+    """Return a juju application's IP address from ``juju status``."""
+    return juju.status().apps[app_name].address
+
+
+def get_ingested_traces_tag_values(tempo_host: str, tag: str, tls: bool = False) -> Set[str]:
+    """Return every value Tempo has seen for a tag (e.g. ``service.name``)."""
+    scheme = "https" if tls else "http"
+    url = f"{scheme}://{tempo_host}:3200/api/search/tag/{tag}/values"
+    resp = requests.get(url, verify=False, timeout=10)
+    resp.raise_for_status()
+    return set(cast(List[str], resp.json()["tagValues"]))

--- a/tests/integration/test_charm_tracing.py
+++ b/tests/integration/test_charm_tracing.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""End-to-end test that the charm's hook spans reach Tempo over `charm-tracing`.
+
+Deploys the charm with a monolithic Tempo cluster, relates `charm-tracing`, and checks
+the charm's spans show up in Tempo. Uses jubilant (the `juju` fixture comes from
+pytest-jubilant).
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import jubilant
+import pytest
+import yaml
+from tempo_helpers import (
+    S3_APP,
+    TEMPO,
+    TEMPO_WORKER,
+    deploy_monolithic_tempo_cluster,
+    get_app_ip_address,
+    get_ingested_traces_tag_values,
+)
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+RESOURCES = {
+    "pushgateway-image": METADATA["resources"]["pushgateway-image"]["upstream-source"]
+}
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_charm_and_tempo(juju: jubilant.Juju, charm: pathlib.Path) -> None:
+    """Deploy the charm and a monolithic Tempo cluster, then integrate charm-tracing."""
+    # GIVEN this charm and a monolithic Tempo stack
+    juju.deploy(charm, APP_NAME, resources=RESOURCES, trust=True)
+    deploy_monolithic_tempo_cluster(juju)
+
+    # WHEN the charm-tracing relation is established with Tempo
+    juju.integrate(f"{APP_NAME}:charm-tracing", f"{TEMPO}:tracing")
+
+    # THEN every application settles into active
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME, TEMPO, TEMPO_WORKER, S3_APP),
+        error=jubilant.any_error,
+        timeout=1000,
+    )
+
+
+@retry(stop=stop_after_attempt(6), wait=wait_fixed(10))
+def test_charm_traces_reach_tempo(juju: jubilant.Juju) -> None:
+    """Assert that this charm's spans actually show up in Tempo."""
+    # GIVEN update-status fires every 5s so a charm-tracing span is emitted quickly
+    juju.model_config({"update-status-hook-interval": "5s"})
+
+    # WHEN we query Tempo for the service names it has ingested
+    services = get_ingested_traces_tag_values(get_app_ip_address(juju, TEMPO), tag="service.name")
+
+    # THEN our charm appears among them
+    assert APP_NAME in services, (
+        f"expected {APP_NAME!r} in ingested services, got: {sorted(services)}"
+    )

--- a/tests/integration/test_loki_integration.py
+++ b/tests/integration/test_loki_integration.py
@@ -39,7 +39,7 @@ async def test_loki_integration(
         ops_test.model.deploy(
             "loki-k8s",
             application_name=loki_app_name,
-            channel="stable",
+            channel="dev/edge",
             trust=True,
         ),
     )

--- a/tests/integration/test_prometheus_integration.py
+++ b/tests/integration/test_prometheus_integration.py
@@ -41,7 +41,7 @@ async def test_prometheus_integration(
         ops_test.model.deploy(
             "prometheus-k8s",
             application_name=prometheus_app_name,
-            channel="stable",
+            channel="dev/edge",
             trust=True,
         ),
         ops_test.model.deploy(

--- a/tests/integration/test_prometheus_integration_tls.py
+++ b/tests/integration/test_prometheus_integration_tls.py
@@ -42,7 +42,7 @@ async def test_prometheus_integration_tls(
         ops_test.model.deploy(
             "prometheus-k8s",
             application_name=prometheus_app_name,
-            channel="edge",
+            channel="dev/edge",
             trust=True,
         ),
         ops_test.model.deploy(

--- a/tests/integration/test_prometheus_integration_tls.py
+++ b/tests/integration/test_prometheus_integration_tls.py
@@ -75,8 +75,10 @@ async def test_prometheus_integration_tls(
         ops_test.model.add_relation(
             f"{APP_NAME}:metrics-endpoint", f"{prometheus_app_name}:metrics-endpoint"
         ),
-        ops_test.model.add_relation(APP_NAME, ca_name),
-        ops_test.model.add_relation(prometheus_app_name, ca_name),
+        ops_test.model.add_relation(f"{APP_NAME}:certificates", f"{ca_name}:certificates"),
+        ops_test.model.add_relation(
+            f"{prometheus_app_name}:certificates", f"{ca_name}:certificates"
+        ),
         ops_test.model.add_relation(f"{tester_name}:pushgateway", f"{APP_NAME}:push-endpoint"),
     )
     logger.info("Relations issued")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Shared fixtures for the scenario-based unit tests."""
+
+import json
+
+import pytest
+from ops import testing
+
+from charm import PrometheusPushgatewayK8SOperatorCharm
+
+# `/bin/pushgateway --version` writes to stderr (see charm._service_version).
+VERSION_EXEC = testing.Exec(
+    command_prefix=["/bin/pushgateway", "--version"],
+    stderr="pushgateway, version 1.11.0 (branch: HEAD, revision: 7afc96cfc3b20e56968ff30eea22)",
+)
+
+
+@pytest.fixture
+def context():
+    """A fresh scenario Context for the charm, loading metadata from charmcraft.yaml."""
+    return testing.Context(PrometheusPushgatewayK8SOperatorCharm, charm_root=".")
+
+
+@pytest.fixture
+def container():
+    """The pushgateway workload container with a stubbed --version exec."""
+    return testing.Container("pushgateway", can_connect=True, execs={VERSION_EXEC})
+
+
+@pytest.fixture
+def charm_tracing_relation():
+    """A charm-tracing relation pointing at a Tempo coordinator over HTTP."""
+    return testing.Relation(
+        endpoint="charm-tracing",
+        interface="tracing",
+        remote_app_name="tempo",
+        remote_app_data={
+            "receivers": json.dumps(
+                [{"protocol": {"name": "otlp_http", "type": "http"}, "url": "http://tempo:4318"}]
+            ),
+        },
+        remote_units_data={0: {}},
+    )
+
+
+@pytest.fixture
+def tls_charm_tracing_relation():
+    """A charm-tracing relation pointing at a Tempo coordinator over HTTPS."""
+    return testing.Relation(
+        endpoint="charm-tracing",
+        interface="tracing",
+        remote_app_name="tempo",
+        remote_app_data={
+            "receivers": json.dumps(
+                [{"protocol": {"name": "otlp_http", "type": "http"}, "url": "https://tempo:4318"}]
+            ),
+        },
+        remote_units_data={0: {}},
+    )
+
+
+@pytest.fixture
+def ca_cert_relation():
+    """A receive-ca-cert relation supplying a CA used to validate TLS to the tracing backend."""
+    return testing.Relation(
+        endpoint="receive-ca-cert",
+        interface="certificate_transfer",
+        remote_app_name="self-signed-certificates",
+        remote_app_data={
+            "ca": "-----BEGIN CERTIFICATE-----\nMIIBfake\n-----END CERTIFICATE-----",
+        },
+        remote_units_data={0: {}},
+    )

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Scenario tests for the charm-tracing wiring.
+
+Assert on the charm's relation databag (the part that's ours), not on ops_tracing itself.
+"""
+
+import json
+
+import pytest
+from ops import testing
+
+
+@pytest.mark.parametrize("tls", (True, False))
+def test_charm_active_with_charm_tracing_relation(
+    context, container, charm_tracing_relation, tls_charm_tracing_relation, ca_cert_relation, tls
+):
+    """The charm reaches active with a tracing relation present, with or without TLS."""
+    # GIVEN a charm whose charm-tracing backend is HTTP or HTTPS
+    tracing_relation = tls_charm_tracing_relation if tls else charm_tracing_relation
+    relations = [tracing_relation] + ([ca_cert_relation] if tls else [])
+    state_in = testing.State(leader=True, containers=[container], relations=relations)
+
+    # WHEN pebble_ready fires
+    state_out = context.run(context.on.pebble_ready(container), state_in)
+
+    # THEN tracing does not get in the way of normal operation
+    assert state_out.unit_status == testing.ActiveStatus()
+
+
+def test_charm_publishes_tracing_receivers_on_relation_changed(
+    context, container, charm_tracing_relation
+):
+    """On relation-changed, the charm advertises the protocols it wants in its own databag."""
+    # GIVEN a leader charm related over charm-tracing
+    state_in = testing.State(
+        leader=True, containers=[container], relations=[charm_tracing_relation]
+    )
+
+    # WHEN the tracing relation data changes
+    state_out = context.run(
+        context.on.relation_changed(charm_tracing_relation, remote_unit=0), state_in
+    )
+
+    # THEN the charm has published the protocols it wants to receive traces on
+    local_app_data = state_out.get_relation(charm_tracing_relation.id).local_app_data
+    assert json.loads(local_app_data["receivers"]) == ["otlp_http"]
+
+
+def test_charm_withdraws_tracing_receivers_on_relation_broken(
+    context, container, charm_tracing_relation
+):
+    """On relation-broken, the charm withdraws its tracing request from the databag."""
+    # GIVEN a leader charm related over charm-tracing
+    state_in = testing.State(
+        leader=True, containers=[container], relations=[charm_tracing_relation]
+    )
+
+    # WHEN the tracing relation is broken
+    state_out = context.run(context.on.relation_broken(charm_tracing_relation), state_in)
+
+    # THEN the charm no longer advertises any tracing protocols
+    local_app_data = state_out.get_relation(charm_tracing_relation.id).local_app_data
+    assert "receivers" not in local_app_data

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8, <4"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -922,7 +922,7 @@ name = "deprecated"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
 wheels = [
@@ -934,7 +934,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1496,6 +1496,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jubilant"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4b/faf53677e40ce2bf836d53d33f97b14a2a5083e25984115fa28a0dd33bb9/jubilant-1.10.0.tar.gz", hash = "sha256:c0040c5e897108ea4efb65bfd3d4bfa0ff62ef91f2a4c6ff6d6dbad8665cc992", size = 33147, upload-time = "2026-05-28T03:54:42.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/af/3ee025257fc62c0285833fa8c2c099a86a65a1d9e37eb4f41e301180deac/jubilant-1.10.0-py3-none-any.whl", hash = "sha256:af437ca48eddb6b9eace888ec60a299b003eb425b20009c21c2f49c86d126741", size = 34744, upload-time = "2026-05-28T03:54:41.074Z" },
+]
+
+[[package]]
 name = "juju"
 version = "3.5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1991,14 +2003,155 @@ wheels = [
 name = "opentelemetry-api"
 version = "1.33.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.6' and python_full_version < '3.9'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.8.6'",
+    "python_full_version < '3.8.1'",
+]
 dependencies = [
-    { name = "deprecated" },
+    { name = "deprecated", marker = "python_full_version < '3.9'" },
     { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "importlib-metadata", version = "8.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8d/1f5a45fbcb9a7d87809d460f09dc3399e3fbd31d7f3e14888345e9d29951/opentelemetry_api-1.33.1.tar.gz", hash = "sha256:1c6055fc0a2d3f23a50c7e17e16ef75ad489345fd3df1f8b8af7c0bbf8a109e8", size = 65002, upload-time = "2025-05-16T18:52:41.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/44/4c45a34def3506122ae61ad684139f0bbc4e00c39555d4f7e20e0e001c8a/opentelemetry_api-1.33.1-py3-none-any.whl", hash = "sha256:4db83ebcf7ea93e64637ec6ee6fabee45c5cbe4abd9cf3da95c43828ddb50b83", size = 65771, upload-time = "2025-05-16T18:52:17.419Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "importlib-metadata", version = "8.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.6' and python_full_version < '3.9'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.8.6'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.54b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/12/909b98a7d9b110cce4b28d49b2e311797cffdce180371f35eba13a72dd00/opentelemetry_sdk-1.33.1.tar.gz", hash = "sha256:85b9fcf7c3d23506fbc9692fd210b8b025a1920535feec50bd54ce203d57a531", size = 161885, upload-time = "2025-05-16T18:52:52.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/8e/ae2d0742041e0bd7fe0d2dcc5e7cce51dcf7d3961a26072d5b43cc8fa2a7/opentelemetry_sdk-1.33.1-py3-none-any.whl", hash = "sha256:19ea73d9a01be29cacaa5d6c8ce0adc0b7f7b4d58cc52f923e4413609f670112", size = 118950, upload-time = "2025-05-16T18:52:37.297Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.41.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.62b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-semantic-conventions", version = "0.63b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.6' and python_full_version < '3.9'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.8.6'",
+    "python_full_version < '3.8.1'",
+]
+dependencies = [
+    { name = "deprecated", marker = "python_full_version < '3.9'" },
+    { name = "opentelemetry-api", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/2c/d7990fc1ffc82889d466e7cd680788ace44a26789809924813b164344393/opentelemetry_semantic_conventions-0.54b1.tar.gz", hash = "sha256:d1cecedae15d19bdaafca1e56b29a66aa286f50b5d08f036a145c7f3e9ef9cee", size = 118642, upload-time = "2025-05-16T18:52:53.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/80/08b1698c52ff76d96ba440bf15edc2f4bc0a279868778928e947c1004bdd/opentelemetry_semantic_conventions-0.54b1-py3-none-any.whl", hash = "sha256:29dab644a7e435b58d3a3918b58c333c92686236b30f7891d5e51f02933ca60d", size = 194938, upload-time = "2025-05-16T18:52:38.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.41.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "opentelemetry-api", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
 ]
 
 [[package]]
@@ -2008,7 +2161,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "importlib-metadata", version = "8.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "opentelemetry-api" },
+    { name = "opentelemetry-api", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "opentelemetry-api", version = "1.41.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "opentelemetry-api", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyyaml" },
     { name = "websocket-client" },
 ]
@@ -2020,6 +2175,9 @@ wheels = [
 [package.optional-dependencies]
 testing = [
     { name = "ops-scenario" },
+]
+tracing = [
+    { name = "ops-tracing" },
 ]
 
 [[package]]
@@ -2033,6 +2191,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/95/90312165f3e1d5876872ad64131be9c0f26b5aa09bd73a436a21b0752820/ops_scenario-7.21.1.tar.gz", hash = "sha256:534b407b34212161c3e74cb396b79ca7449932e483053e924146fdf0140876b9", size = 141631, upload-time = "2025-05-01T03:03:30.456Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/3b/4cc28ea9d77015ecf8fc5c3d362bb274e35ffaa2e6fbd87909a5384afa40/ops_scenario-7.21.1-py3-none-any.whl", hash = "sha256:eeb9def2c31a1db2429cf21bd9b8cbd2ac092cc1fbe5591e850e4aa192c542fa", size = 72451, upload-time = "2025-05-01T03:03:28.488Z" },
+]
+
+[[package]]
+name = "ops-tracing"
+version = "2.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-sdk", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "opentelemetry-sdk", version = "1.41.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "opentelemetry-sdk", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ops" },
+    { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/1d/8c028b996ef5cc320064e63b8497cc95dbd4cb6be730012f12046ac50d43/ops_tracing-2.21.1.tar.gz", hash = "sha256:d1dc8ecd079a4d78f3d6978bda16b884d1dc00792db0d8e9273912a87cf2cafc", size = 27871, upload-time = "2025-05-01T03:03:18.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/22/d75274cd8775a016b925fd7a3a4040b890a3be797285d4f6c56ab0c2b471/ops_tracing-2.21.1-py3-none-any.whl", hash = "sha256:e84900361806481e74b0c1855c52a85552a3a3edaaea06f47846f934a2ffa5b2", size = 31177, upload-time = "2025-05-01T03:03:16.918Z" },
 ]
 
 [[package]]
@@ -2143,7 +2318,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "jsonschema", version = "4.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "jsonschema", version = "4.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "ops" },
+    { name = "ops", extra = ["tracing"] },
     { name = "parse" },
     { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -2156,15 +2331,20 @@ dev = [
     { name = "codespell" },
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.8.2", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.9'" },
+    { name = "jubilant" },
     { name = "juju", version = "3.5.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.6'" },
     { name = "juju", version = "3.6.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.6'" },
     { name = "ops", extra = ["testing"] },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-jubilant" },
     { name = "pytest-operator" },
+    { name = "requests" },
     { name = "ruff" },
     { name = "sh", version = "1.14.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
     { name = "sh", version = "2.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1'" },
+    { name = "tenacity", version = "9.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "tenacity", version = "9.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 
 [package.metadata]
@@ -2175,16 +2355,20 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "cryptography" },
     { name = "jsonschema" },
+    { name = "jubilant", marker = "extra == 'dev'" },
     { name = "juju", marker = "extra == 'dev'", specifier = ">=3.5" },
-    { name = "ops", specifier = ">=2.2" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
+    { name = "ops", extras = ["tracing"], specifier = ">=2.2" },
     { name = "parse" },
     { name = "pydantic" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-jubilant", marker = "extra == 'dev'" },
     { name = "pytest-operator", marker = "extra == 'dev'", specifier = ">=0.39" },
+    { name = "requests", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sh", marker = "extra == 'dev'" },
+    { name = "tenacity", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
 
@@ -2875,6 +3059,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/53/57663d99acaac2fcdafdc697e52a9b1b7d6fcf36616281ff9768a44e7ff3/pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45", size = 30656, upload-time = "2024-04-29T13:23:24.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/ce/1e4b53c213dce25d6e8b163697fbce2d43799d76fa08eea6ad270451c370/pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b", size = 13368, upload-time = "2024-04-29T13:23:23.126Z" },
+]
+
+[[package]]
+name = "pytest-jubilant"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jubilant" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/64/e83181af1004f64a3ce11c7b9770c3152832e02d00e9e7b4f01877325c5f/pytest_jubilant-2.0.1.tar.gz", hash = "sha256:960bb63d216ec746f7644b67c276b059fccdaa258ee7644aaa74058db659edac", size = 16311, upload-time = "2026-04-07T02:08:25.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/3c/5c0bc4f54f6905aa7515cf764c3f5d6c85711cdc1a928221f711d5b7532c/pytest_jubilant-2.0.1-py3-none-any.whl", hash = "sha256:df498ee79d6db5ec32baa35a121ab75852dd50f61504a12550ba81cd63a7f1ef", size = 13525, upload-time = "2026-04-07T02:08:24.531Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue

Closes #52

## What

Adds charm tracing so `prometheus-pushgateway-k8s` exports its own hook executions as traces to a distributed tracing backend (e.g. Tempo), using the modern `ops[tracing]` / `ops_tracing.Tracing` integration. Follows the same pattern as the sibling charms (canonical/prometheus-scrape-config-k8s-operator#77, canonical/blackbox-exporter-k8s-operator#95).

- **charmcraft.yaml**: add optional `requires` relations `charm-tracing` (interface `tracing`) and `receive-ca-cert` (interface `certificate_transfer`).
- **pyproject.toml**: `ops` → `ops[tracing]`; add `jubilant`, `pytest-jubilant`, `requests`, `tenacity` for the jubilant integration suite (`uv.lock` regenerated).
- **src/charm.py**: wire up `ops_tracing.Tracing(self, tracing_relation_name="charm-tracing", ca_relation_name="receive-ca-cert")`.
- **tests**: scenario unit tests (`tests/unit/test_tracing.py` + fixtures) and a jubilant integration test (`tests/integration/test_charm_tracing.py` + `tempo_helpers.py`).

## Testing

- `tox -e lint` / `-e static` / `-e unit` — all green (27 unit tests pass, pyright clean).
- Integration: `tests/integration/test_charm_tracing.py` run against a microk8s + Tempo environment — **2 passed**; `prometheus-pushgateway-k8s` confirmed in Tempo's ingested `service.name` values and `ops.main` traces viewable in Grafana.